### PR TITLE
Removed Muse from host list, added bridge

### DIFF
--- a/CSXS/manifest.xml
+++ b/CSXS/manifest.xml
@@ -32,10 +32,11 @@
             <Host Name="AUDT" Version="8" />
             <!-- Dreamweaver -->
             <Host Name="DRWV" Version="16" />
-            <!-- Muse (I don't know the version number for 2017 -->
-            <!-- never used it don't care, not a.muse.d -->
-            <Host Name="MUSE" Version="2" />
-
+            <HostList>
+            <!-- Bridge -->   
+            <Host Name="KBRG" Version="[8.0]" />
+            </HostList>
+            
         </HostList>
         <LocaleList>
             <Locale Code="All" />


### PR DESCRIPTION
Muse is only supported for internal use by Adobe for the CC libraries extension. Bridge support is new, may require CEP 7 rather than 6, but not all applications support CEP 7 yet.